### PR TITLE
Close div

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -13,4 +13,5 @@
       </ol>
     </div>
   </div>
+  </div>
 </section>


### PR DESCRIPTION
Avoid:
```
  Error: End tag section seen, but there were open elements.
  Error: Unclosed element div.
```